### PR TITLE
Automagical features

### DIFF
--- a/novideo_srgb/DisplayConfigManager.cs
+++ b/novideo_srgb/DisplayConfigManager.cs
@@ -1,0 +1,388 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace novideo_srgb
+{
+    public static class DisplayConfigManager
+    {
+        [DllImport("user32")]
+        private static extern int GetDisplayConfigBufferSizes(QDC flags, out int numPathArrayElements, out int numModeInfoArrayElements);
+
+        [DllImport("user32")]
+        private static extern int QueryDisplayConfig(QDC flags, ref int numPathArrayElements, [In, Out] DISPLAYCONFIG_PATH_INFO[] pathArray, ref int numModeInfoArrayElements, [In, Out] DISPLAYCONFIG_MODE_INFO[] modeInfoArray, out DISPLAYCONFIG_TOPOLOGY_ID currentTopologyId);
+
+        [DllImport("user32")]
+        private static extern int QueryDisplayConfig(QDC flags, ref int numPathArrayElements, [In, Out] DISPLAYCONFIG_PATH_INFO[] pathArray, ref int numModeInfoArrayElements, [In, Out] DISPLAYCONFIG_MODE_INFO[] modeInfoArray, IntPtr currentTopologyId);
+
+        [DllImport("user32")]
+        private static extern int DisplayConfigGetDeviceInfo(ref DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO requestPacket);
+
+        [DllImport("user32")]
+        private static extern int DisplayConfigGetDeviceInfo(ref DISPLAYCONFIG_SOURCE_DEVICE_NAME requestPacket);
+
+        [DllImport("user32")]
+        private static extern int DisplayConfigGetDeviceInfo(ref DISPLAYCONFIG_TARGET_DEVICE_NAME requestPacket);
+
+        public static DisplayHdrStatus GetDisplayHdrStatus()
+        {
+            Action<int> check = (e) =>
+            {
+                if (e != 0)
+                {
+                    throw new Win32Exception(e);
+                }
+            };
+
+            check(GetDisplayConfigBufferSizes(QDC.QDC_ONLY_ACTIVE_PATHS, out var pathCount, out var modeCount));
+
+            var paths = new DISPLAYCONFIG_PATH_INFO[pathCount];
+            var modes = new DISPLAYCONFIG_MODE_INFO[modeCount];
+
+            check(QueryDisplayConfig(QDC.QDC_ONLY_ACTIVE_PATHS, ref pathCount, paths, ref modeCount, modes, IntPtr.Zero));
+
+            var result = DisplayHdrStatus.Disabled;
+
+            paths.ToList().ForEach(path =>
+            {
+                var displayInfo = new DISPLAYCONFIG_TARGET_DEVICE_NAME();
+                displayInfo.header.type = DISPLAYCONFIG_DEVICE_INFO_TYPE.DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME;
+                displayInfo.header.size = Marshal.SizeOf<DISPLAYCONFIG_TARGET_DEVICE_NAME>();
+                displayInfo.header.adapterId = path.targetInfo.adapterId;
+                displayInfo.header.id = path.targetInfo.id;
+
+                check(DisplayConfigGetDeviceInfo(ref displayInfo));
+
+                var colorInfo = new DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO();
+                colorInfo.header.type = DISPLAYCONFIG_DEVICE_INFO_TYPE.DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO;
+                colorInfo.header.size = Marshal.SizeOf<DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO>();
+                colorInfo.header.adapterId = path.targetInfo.adapterId;
+                colorInfo.header.id = path.targetInfo.id;
+
+                check(DisplayConfigGetDeviceInfo(ref colorInfo));
+
+                result = colorInfo.advancedColorEnabled ? DisplayHdrStatus.Enabled : DisplayHdrStatus.Disabled;
+            });
+
+            return result;
+        }
+    }
+
+    public enum DisplayHdrStatus
+    {
+        Enabled,
+        Disabled
+    }
+
+    internal enum DISPLAYCONFIG_DEVICE_INFO_TYPE
+    {
+        DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME = 1,
+        DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME = 2,
+        DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_PREFERRED_MODE = 3,
+        DISPLAYCONFIG_DEVICE_INFO_GET_ADAPTER_NAME = 4,
+        DISPLAYCONFIG_DEVICE_INFO_SET_TARGET_PERSISTENCE = 5,
+        DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_BASE_TYPE = 6,
+        DISPLAYCONFIG_DEVICE_INFO_GET_SUPPORT_VIRTUAL_RESOLUTION = 7,
+        DISPLAYCONFIG_DEVICE_INFO_SET_SUPPORT_VIRTUAL_RESOLUTION = 8,
+        DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO = 9,
+        DISPLAYCONFIG_DEVICE_INFO_SET_ADVANCED_COLOR_STATE = 10,
+        DISPLAYCONFIG_DEVICE_INFO_GET_SDR_WHITE_LEVEL = 11,
+    }
+
+    internal enum DISPLAYCONFIG_COLOR_ENCODING
+    {
+        DISPLAYCONFIG_COLOR_ENCODING_RGB = 0,
+        DISPLAYCONFIG_COLOR_ENCODING_YCBCR444 = 1,
+        DISPLAYCONFIG_COLOR_ENCODING_YCBCR422 = 2,
+        DISPLAYCONFIG_COLOR_ENCODING_YCBCR420 = 3,
+        DISPLAYCONFIG_COLOR_ENCODING_INTENSITY = 4,
+    }
+
+    internal enum DISPLAYCONFIG_SCALING
+    {
+        DISPLAYCONFIG_SCALING_IDENTITY = 1,
+        DISPLAYCONFIG_SCALING_CENTERED = 2,
+        DISPLAYCONFIG_SCALING_STRETCHED = 3,
+        DISPLAYCONFIG_SCALING_ASPECTRATIOCENTEREDMAX = 4,
+        DISPLAYCONFIG_SCALING_CUSTOM = 5,
+        DISPLAYCONFIG_SCALING_PREFERRED = 128,
+    }
+
+    internal enum DISPLAYCONFIG_ROTATION
+    {
+        DISPLAYCONFIG_ROTATION_IDENTITY = 1,
+        DISPLAYCONFIG_ROTATION_ROTATE90 = 2,
+        DISPLAYCONFIG_ROTATION_ROTATE180 = 3,
+    }
+
+    internal enum DISPLAYCONFIG_VIDEO_OUTPUT_TECHNOLOGY
+    {
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_OTHER = -1,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_HD15 = 0,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_SVIDEO = 1,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_COMPOSITE_VIDEO = 2,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_COMPONENT_VIDEO = 3,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_DVI = 4,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_HDMI = 5,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_LVDS = 6,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_D_JPN = 8,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_SDI = 9,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_DISPLAYPORT_EXTERNAL = 10,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_DISPLAYPORT_EMBEDDED = 11,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_UDI_EXTERNAL = 12,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_UDI_EMBEDDED = 13,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_SDTVDONGLE = 14,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_MIRACAST = 15,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_INDIRECT_WIRED = 16,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_INDIRECT_VIRTUAL = 17,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_INTERNAL = unchecked((int)0x80000000),
+    }
+
+    internal enum DISPLAYCONFIG_TOPOLOGY_ID
+    {
+        DISPLAYCONFIG_TOPOLOGY_INTERNAL = 0x00000001,
+        DISPLAYCONFIG_TOPOLOGY_CLONE = 0x00000002,
+        DISPLAYCONFIG_TOPOLOGY_EXTEND = 0x00000004,
+        DISPLAYCONFIG_TOPOLOGY_EXTERNAL = 0x00000008,
+    }
+
+    internal enum DISPLAYCONFIG_PATH
+    {
+        DISPLAYCONFIG_PATH_ACTIVE = 0x00000001,
+        DISPLAYCONFIG_PATH_PREFERRED_UNSCALED = 0x00000004,
+        DISPLAYCONFIG_PATH_SUPPORT_VIRTUAL_MODE = 0x00000008,
+    }
+
+    internal enum DISPLAYCONFIG_SOURCE_FLAGS
+    {
+        DISPLAYCONFIG_SOURCE_IN_USE = 0x00000001,
+    }
+
+    internal enum DISPLAYCONFIG_TARGET_FLAGS
+    {
+        DISPLAYCONFIG_TARGET_IN_USE = 0x00000001,
+        DISPLAYCONFIG_TARGET_FORCIBLE = 0x00000002,
+        DISPLAYCONFIG_TARGET_FORCED_AVAILABILITY_BOOT = 0x00000004,
+        DISPLAYCONFIG_TARGET_FORCED_AVAILABILITY_PATH = 0x00000008,
+        DISPLAYCONFIG_TARGET_FORCED_AVAILABILITY_SYSTEM = 0x00000010,
+        DISPLAYCONFIG_TARGET_IS_HMD = 0x00000020,
+    }
+
+    internal enum QDC
+    {
+        QDC_ALL_PATHS = 0x00000001,
+        QDC_ONLY_ACTIVE_PATHS = 0x00000002,
+        QDC_DATABASE_CURRENT = 0x00000004,
+        QDC_VIRTUAL_MODE_AWARE = 0x00000010,
+        QDC_INCLUDE_HMD = 0x00000020,
+    }
+
+    internal enum DISPLAYCONFIG_SCANLINE_ORDERING
+    {
+        DISPLAYCONFIG_SCANLINE_ORDERING_UNSPECIFIED = 0,
+        DISPLAYCONFIG_SCANLINE_ORDERING_PROGRESSIVE = 1,
+        DISPLAYCONFIG_SCANLINE_ORDERING_INTERLACED = 2,
+        DISPLAYCONFIG_SCANLINE_ORDERING_INTERLACED_UPPERFIELDFIRST = DISPLAYCONFIG_SCANLINE_ORDERING_INTERLACED,
+        DISPLAYCONFIG_SCANLINE_ORDERING_INTERLACED_LOWERFIELDFIRST = 3,
+    }
+
+    internal enum DISPLAYCONFIG_PIXELFORMAT
+    {
+        DISPLAYCONFIG_PIXELFORMAT_8BPP = 1,
+        DISPLAYCONFIG_PIXELFORMAT_16BPP = 2,
+        DISPLAYCONFIG_PIXELFORMAT_24BPP = 3,
+        DISPLAYCONFIG_PIXELFORMAT_32BPP = 4,
+        DISPLAYCONFIG_PIXELFORMAT_NONGDI = 5,
+    }
+
+    internal enum DISPLAYCONFIG_MODE_INFO_TYPE
+    {
+        DISPLAYCONFIG_MODE_INFO_TYPE_SOURCE = 1,
+        DISPLAYCONFIG_MODE_INFO_TYPE_TARGET = 2,
+        DISPLAYCONFIG_MODE_INFO_TYPE_DESKTOP_IMAGE = 3,
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct DISPLAYCONFIG_DEVICE_INFO_HEADER
+    {
+        public DISPLAYCONFIG_DEVICE_INFO_TYPE type;
+        public int size;
+        public LUID adapterId;
+        public uint id;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO
+    {
+        public DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+        public uint value;
+        public DISPLAYCONFIG_COLOR_ENCODING colorEncoding;
+        public int bitsPerColorChannel;
+
+        public bool advancedColorSupported => (value & 0x1) == 0x1;
+        public bool advancedColorEnabled => (value & 0x2) == 0x2;
+        public bool wideColorEnforced => (value & 0x4) == 0x4;
+        public bool advancedColorForceDisabled => (value & 0x8) == 0x8;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct POINTL
+    {
+        public int x;
+        public int y;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct LUID
+    {
+        public uint LowPart;
+        public int HighPart;
+
+        public long Value => ((long)HighPart << 32) | LowPart;
+        public override string ToString() => Value.ToString();
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct DISPLAYCONFIG_SOURCE_MODE
+    {
+        public uint width;
+        public uint height;
+        public DISPLAYCONFIG_PIXELFORMAT pixelFormat;
+        public POINTL position;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct DISPLAYCONFIG_RATIONAL
+    {
+        public uint Numerator;
+        public uint Denominator;
+
+        public override string ToString() => Numerator + " / " + Denominator;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct DISPLAYCONFIG_2DREGION
+    {
+        public uint cx;
+        public uint cy;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct DISPLAYCONFIG_DESKTOP_IMAGE_INFO
+    {
+        public POINTL PathSourceSize;
+        public RECT DesktopImageRegion;
+        public RECT DesktopImageClip;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct DISPLAYCONFIG_VIDEO_SIGNAL_INFO
+    {
+        public ulong pixelRate;
+        public DISPLAYCONFIG_RATIONAL hSyncFreq;
+        public DISPLAYCONFIG_RATIONAL vSyncFreq;
+        public DISPLAYCONFIG_2DREGION activeSize;
+        public DISPLAYCONFIG_2DREGION totalSize;
+        public uint videoStandard;
+        public DISPLAYCONFIG_SCANLINE_ORDERING scanLineOrdering;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct DISPLAYCONFIG_TARGET_MODE
+    {
+        public DISPLAYCONFIG_VIDEO_SIGNAL_INFO targetVideoSignalInfo;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    internal struct DISPLAYCONFIG_MODE_INFO_union
+    {
+        [FieldOffset(0)]
+        public DISPLAYCONFIG_TARGET_MODE targetMode;
+
+        [FieldOffset(0)]
+        public DISPLAYCONFIG_SOURCE_MODE sourceMode;
+
+        [FieldOffset(0)]
+        public DISPLAYCONFIG_DESKTOP_IMAGE_INFO desktopImageInfo;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct DISPLAYCONFIG_PATH_SOURCE_INFO
+    {
+        public LUID adapterId;
+        public uint id;
+        public uint modeInfoIdx;
+        public DISPLAYCONFIG_SOURCE_FLAGS statusFlags;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct DISPLAYCONFIG_PATH_TARGET_INFO
+    {
+        public LUID adapterId;
+        public uint id;
+        public uint modeInfoIdx;
+        public DISPLAYCONFIG_VIDEO_OUTPUT_TECHNOLOGY outputTechnology;
+        public DISPLAYCONFIG_ROTATION rotation;
+        public DISPLAYCONFIG_SCALING scaling;
+        public DISPLAYCONFIG_RATIONAL refreshRate;
+        public DISPLAYCONFIG_SCANLINE_ORDERING scanLineOrdering;
+        public bool targetAvailable;
+        public DISPLAYCONFIG_TARGET_FLAGS statusFlags;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct DISPLAYCONFIG_PATH_INFO
+    {
+        public DISPLAYCONFIG_PATH_SOURCE_INFO sourceInfo;
+        public DISPLAYCONFIG_PATH_TARGET_INFO targetInfo;
+        public DISPLAYCONFIG_PATH flags;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct DISPLAYCONFIG_MODE_INFO
+    {
+        public DISPLAYCONFIG_MODE_INFO_TYPE infoType;
+        public uint id;
+        public LUID adapterId;
+        public DISPLAYCONFIG_MODE_INFO_union info;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    internal struct DISPLAYCONFIG_SOURCE_DEVICE_NAME
+    {
+        public DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+        public string viewGdiDeviceName;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    internal struct DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS
+    {
+        public uint value;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    internal struct DISPLAYCONFIG_TARGET_DEVICE_NAME
+    {
+        public DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+        public DISPLAYCONFIG_TARGET_DEVICE_NAME_FLAGS flags;
+        public DISPLAYCONFIG_VIDEO_OUTPUT_TECHNOLOGY outputTechnology;
+        public ushort edidManufactureId;
+        public ushort edidProductCodeId;
+        public uint connectorInstance;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 64)]
+        public string monitorFriendlyDeviceName;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+        public string monitorDevicePat;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct RECT
+    {
+        public int left;
+        public int top;
+        public int right;
+        public int bottom;
+    }
+}

--- a/novideo_srgb/MainWindow.xaml
+++ b/novideo_srgb/MainWindow.xaml
@@ -11,8 +11,12 @@
         <local:MainViewModel />
     </Window.DataContext>
     <DockPanel Margin="6,0,6,6">
-        <Button DockPanel.Dock="Bottom" Content="About" Width="75" HorizontalAlignment="Left"
-                Click="AboutButton_Click" />
+        <Grid DockPanel.Dock="Bottom">
+            <Button DockPanel.Dock="Bottom" Content="About" Width="75" HorizontalAlignment="Left"
+                    Click="AboutButton_Click" />
+            <Button DockPanel.Dock="Bottom" Content="Hide" Width="75" HorizontalAlignment="Right"
+                    Click="MinimizeToTrayButton_Click" />
+        </Grid>
         <DataGrid ItemsSource="{Binding Monitors}" RowHeaderWidth="0" AutoGenerateColumns="False"
                   DockPanel.Dock="Bottom" Margin="0,0,0,6" CanUserResizeColumns="False" CanUserSortColumns="False"
                   CanUserReorderColumns="False">

--- a/novideo_srgb/MainWindow.xaml.cs
+++ b/novideo_srgb/MainWindow.xaml.cs
@@ -1,19 +1,24 @@
-﻿using System;
+﻿using Microsoft.Win32;
+using novideo_srgb.PowerBroadcast;
+using System;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
-using Microsoft.Win32;
+using System.Windows.Interop;
 
 namespace novideo_srgb
 {
     public partial class MainWindow
     {
         private readonly MainViewModel _viewModel;
+        private System.Windows.Forms.NotifyIcon _trayIcon;
 
         public MainWindow()
         {
             InitializeComponent();
             _viewModel = (MainViewModel)DataContext;
             SystemEvents.DisplaySettingsChanged += _viewModel.OnDisplaySettingsChanged;
+            InitializeTrayIcon();
         }
 
         private void AboutButton_Click(object sender, RoutedEventArgs o)
@@ -55,5 +60,113 @@ namespace novideo_srgb
                     Math.Max(window.DitherMode.SelectedIndex, 0));
             }
         }
+
+        private async Task DeferAction(Action action, int seconds)
+        {
+            await Task.Delay(seconds);
+            action();
+        }
+
+        private IntPtr HandleMessages(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled) => PowerBroadcastNotificationHelpers.HandleBroadcastNotification(msg, lParam, (message) =>
+        {
+            if (((char)message.Data) == (char)ConsoleDisplayState.TurnedOn)
+            {
+                _ = DeferAction(ReapplyMonitorSettings, 150);
+            }
+        });
+
+        private void MinimizeToTray()
+        {
+            Hide();
+            ShowInTaskbar = false;
+        }
+
+        private void InitializeTrayIcon()
+        {
+            _trayIcon = new System.Windows.Forms.NotifyIcon
+            {
+                Text = "Novideo sRGB",
+                Icon = Properties.Resources.icon,
+                Visible = true
+            };
+
+            _trayIcon.ContextMenuStrip = new System.Windows.Forms.ContextMenuStrip();
+            _trayIcon.ContextMenuStrip.Items.Add("Hide", null, TrayIcon_Hide_Click);
+            _trayIcon.ContextMenuStrip.Items.Add("Restore", null, TrayIcon_Restore_Click);
+            _trayIcon.ContextMenuStrip.Items.Add("Quit", null, TrayIcon_Quit_Click);
+
+            _trayIcon.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(TrayIcon_DoubleClick);
+        }
+
+        private void MinimizeToTrayButton_Click(object sender, RoutedEventArgs e) => MinimizeToTray();
+
+        protected override void OnClosed(EventArgs e)
+        {
+            _trayIcon.Dispose();
+            SystemEvents.DisplaySettingsChanged -= OnDisplaySettingsChanged;
+            base.OnClosed(e);
+        }
+
+        private void OnDisplaySettingsChanged(object sender, EventArgs e)
+        {
+            /*
+             * TODO: This needs to work on a per-monitor basis.
+             * GetDisplayHdrStatus loops through all monitors and returns the result only for the last one.
+             * I'm not seeing an obvious way to tie monitor data grabbed from the Nvidia API to that gathered from the Windows API.
+             * Maybe investigate whether the Nvidia API can tell us whether HDR is enabled on a display?
+             * This might not be a problem, as I think Windows does not allow mixed SDR and HDR multi monitor configurations.
+            */
+            var hdrStatus = DisplayConfigManager.GetDisplayHdrStatus();
+            var clamp = hdrStatus == DisplayHdrStatus.Disabled ? true : false;
+
+            foreach (var monitor in _viewModel.Monitors)
+            {
+                monitor.Clamped = clamp;
+                monitor.ReapplyClamp();
+            }
+        }
+
+        protected override void OnSourceInitialized(EventArgs e)
+        {
+            SystemEvents.DisplaySettingsChanged += new EventHandler(OnDisplaySettingsChanged);
+            base.OnSourceInitialized(e);
+            var handle = new WindowInteropHelper(this).Handle;
+            PowerBroadcastNotificationHelpers.RegisterPowerBroadcastNotification(handle, PowerSettingGuids.CONSOLE_DISPLAY_STATE);
+            HwndSource.FromHwnd(handle)?.AddHook(HandleMessages);
+        }
+
+        private void ReapplyMonitorSettings()
+        {
+            foreach (var monitor in _viewModel.Monitors)
+            {
+                monitor.ReapplyClamp();
+            }
+        }
+
+        private void Restore()
+        {
+            Show();
+            WindowState = WindowState.Normal;
+            ShowInTaskbar = true;
+            Activate();
+        }
+
+        private void TrayIcon_DoubleClick(object sender, EventArgs e)
+        {
+            if(ShowInTaskbar == false || WindowState == WindowState.Minimized)
+            {
+                Restore();
+            }
+            else
+            {
+                MinimizeToTray();
+            }
+        }
+
+        private void TrayIcon_Hide_Click(object sender, EventArgs e) => MinimizeToTray();
+
+        private void TrayIcon_Restore_Click(object sender, EventArgs e) => Restore();
+
+        private void TrayIcon_Quit_Click(object sender, EventArgs e) => Application.Current.Shutdown();
     }
 }

--- a/novideo_srgb/PowerBroadcast/ConsoleDisplayState.cs
+++ b/novideo_srgb/PowerBroadcast/ConsoleDisplayState.cs
@@ -1,0 +1,9 @@
+﻿namespace novideo_srgb.PowerBroadcast
+{
+    public enum ConsoleDisplayState
+    {
+        TurnedOff,
+        TurnedOn,
+        Dimmed
+    }
+}

--- a/novideo_srgb/PowerBroadcast/PowerBroadcastMessage.cs
+++ b/novideo_srgb/PowerBroadcast/PowerBroadcastMessage.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace novideo_srgb.PowerBroadcast
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct PowerBroadcastMessage
+    {
+        public Guid PowerSetting;
+        public uint DataLength;
+        public byte Data;
+    }
+}

--- a/novideo_srgb/PowerBroadcast/PowerBroadcastNotificationHelpers.cs
+++ b/novideo_srgb/PowerBroadcast/PowerBroadcastNotificationHelpers.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+/*
+ * Class for subscribing to WM_POWERBROADCAST messages
+ * See https://docs.microsoft.com/en-us/windows/win32/power/power-setting-guids
+ * for MS documentation on power broadcast values
+ */
+
+namespace novideo_srgb.PowerBroadcast
+{
+    public static class PowerBroadcastNotificationHelpers
+    {
+        private static readonly int WM_POWERBROADCAST = 0x0218;
+
+        [DllImport(@"User32", SetLastError = true,
+                              EntryPoint = "RegisterPowerSettingNotification",
+                              CallingConvention = CallingConvention.StdCall)]
+        private static extern IntPtr RegisterPowerSettingNotification(
+            IntPtr hRecipient,
+            ref Guid PowerSettingGuid,
+            int Flags);
+
+        public static void RegisterPowerBroadcastNotification(IntPtr handle, Guid PowerSetting) => RegisterPowerSettingNotification(handle, ref PowerSetting, 0x00);
+
+        public static IntPtr HandleBroadcastNotification(int msg, IntPtr lParam, Action<PowerBroadcastMessage> action)
+        {
+            if (msg == WM_POWERBROADCAST)
+            {
+                var message = Marshal.PtrToStructure<PowerBroadcastMessage>(lParam);
+                action(message);
+            }
+
+            return IntPtr.Zero;
+        }
+    }
+}

--- a/novideo_srgb/PowerBroadcast/PowerSettingGuids.cs
+++ b/novideo_srgb/PowerBroadcast/PowerSettingGuids.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace novideo_srgb.PowerBroadcast
+{
+    public static class PowerSettingGuids
+    {
+        //More GUIDS available at https://docs.microsoft.com/en-us/windows/win32/power/power-setting-guids
+        public static readonly Guid CONSOLE_DISPLAY_STATE = new Guid("6FE69556-704A-47A0-8F24-C28D936FDA47");
+    }
+}

--- a/novideo_srgb/Properties/Resources.Designer.cs
+++ b/novideo_srgb/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace novideo_srgb.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -57,6 +57,16 @@ namespace novideo_srgb.Properties {
             }
             set {
                 resourceCulture = value;
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Icon similar to (Icon).
+        /// </summary>
+        internal static System.Drawing.Icon icon {
+            get {
+                object obj = ResourceManager.GetObject("icon", resourceCulture);
+                return ((System.Drawing.Icon)(obj));
             }
         }
     }

--- a/novideo_srgb/Properties/Resources.resx
+++ b/novideo_srgb/Properties/Resources.resx
@@ -1,122 +1,124 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-    <!-- 
-      Microsoft ResX Schema 
-      
-      Version 2.0
-      
-      The primary goals of this format is to allow a simple XML format 
-      that is mostly human readable. The generation and parsing of the 
-      various data types are done through the TypeConverter classes 
-      associated with the data types.
-      
-      Example:
-      
-      ... ado.net/XML headers & schema ...
-      <resheader name="resmimetype">text/microsoft-resx</resheader>
-      <resheader name="version">2.0</resheader>
-      <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-      <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-      <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-      <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-      <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-          <value>[base64 mime encoded serialized .NET Framework object]</value>
-      </data>
-      <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-          <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-          <comment>This is a comment</comment>
-      </data>
-                  
-      There are any number of "resheader" rows that contain simple 
-      name/value pairs.
-      
-      Each data row contains a name, and value. The row also contains a 
-      type or mimetype. Type corresponds to a .NET class that support 
-      text/value conversion through the TypeConverter architecture. 
-      Classes that don't support this are serialized and stored with the 
-      mimetype set.
-      
-      The mimetype is used for serialized objects, and tells the 
-      ResXResourceReader how to depersist the object. This is currently not 
-      extensible. For a given mimetype the value must be set accordingly:
-      
-      Note - application/x-microsoft.net.object.binary.base64 is the format 
-      that the ResXResourceWriter will generate, however the reader can 
-      read any of the formats listed below.
-      
-      mimetype: application/x-microsoft.net.object.binary.base64
-      value   : The object must be serialized with 
-              : System.Serialization.Formatters.Binary.BinaryFormatter
-              : and then encoded with base64 encoding.
-      
-      mimetype: application/x-microsoft.net.object.soap.base64
-      value   : The object must be serialized with 
-              : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-              : and then encoded with base64 encoding.
-  
-      mimetype: application/x-microsoft.net.object.bytearray.base64
-      value   : The object must be serialized into a byte array 
-              : using a System.ComponentModel.TypeConverter
-              : and then encoded with base64 encoding.
-      -->
-    <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-                xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-        <xsd:element name="root" msdata:IsDataSet="true">
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
             <xsd:complexType>
-                <xsd:choice maxOccurs="unbounded">
-                    <xsd:element name="metadata">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
-                            </xsd:sequence>
-                            <xsd:attribute name="name" type="xsd:string"/>
-                            <xsd:attribute name="type" type="xsd:string"/>
-                            <xsd:attribute name="mimetype" type="xsd:string"/>
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name="assembly">
-                        <xsd:complexType>
-                            <xsd:attribute name="alias" type="xsd:string"/>
-                            <xsd:attribute name="name" type="xsd:string"/>
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name="data">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
-                            </xsd:sequence>
-                            <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1"/>
-                            <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
-                            <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name="resheader">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
-                            </xsd:sequence>
-                            <xsd:attribute name="name" type="xsd:string" use="required"/>
-                        </xsd:complexType>
-                    </xsd:element>
-                </xsd:choice>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
-        </xsd:element>
-    </xsd:schema>
-    <resheader name="resmimetype">
-        <value>text/microsoft-resx</value>
-    </resheader>
-    <resheader name="version">
-        <value>2.0</value>
-    </resheader>
-    <resheader name="reader">
-        <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral,
-            PublicKeyToken=b77a5c561934e089
-        </value>
-    </resheader>
-    <resheader name="writer">
-        <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral,
-            PublicKeyToken=b77a5c561934e089
-        </value>
-    </resheader>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="icon" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\icon.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
 </root>

--- a/novideo_srgb/novideo_srgb.csproj
+++ b/novideo_srgb/novideo_srgb.csproj
@@ -1,165 +1,172 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/>
-    <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <ProjectGuid>{A6A97834-7BE1-474A-B92F-A512DB1D5186}</ProjectGuid>
-        <OutputType>WinExe</OutputType>
-        <RootNamespace>novideo_srgb</RootNamespace>
-        <AssemblyName>novideo_srgb</AssemblyName>
-        <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-        <FileAlignment>512</FileAlignment>
-        <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-        <WarningLevel>4</WarningLevel>
-        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-        <Deterministic>true</Deterministic>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>bin\Debug\</OutputPath>
-        <DefineConstants>DEBUG;TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugType>pdbonly</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>bin\Release\</OutputPath>
-        <DefineConstants>TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-        <DebugSymbols>true</DebugSymbols>
-        <OutputPath>bin\x64\Debug\</OutputPath>
-        <DefineConstants>DEBUG;TRACE</DefineConstants>
-        <DebugType>full</DebugType>
-        <PlatformTarget>x64</PlatformTarget>
-        <LangVersion>7.3</LangVersion>
-        <ErrorReport>prompt</ErrorReport>
-        <Prefer32Bit>true</Prefer32Bit>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-        <OutputPath>bin\x64\Release\</OutputPath>
-        <DefineConstants>TRACE</DefineConstants>
-        <Optimize>true</Optimize>
-        <DebugType>none</DebugType>
-        <PlatformTarget>x64</PlatformTarget>
-        <LangVersion>7.3</LangVersion>
-        <ErrorReport>prompt</ErrorReport>
-        <Prefer32Bit>true</Prefer32Bit>
-    </PropertyGroup>
-    <PropertyGroup>
-        <ApplicationIcon>icon.ico</ApplicationIcon>
-    </PropertyGroup>
-    <ItemGroup>
-        <Reference Include="EDIDParser, Version=1.2.5.3, Culture=neutral, PublicKeyToken=310fd07b25df79b3">
-            <HintPath>..\packages\EDIDParser.1.2.5.4\lib\net45\EDIDParser.dll</HintPath>
-            <Private>True</Private>
-        </Reference>
-        <Reference Include="NvAPIWrapper, Version=0.8.1.100, Culture=neutral, PublicKeyToken=310fd07b25df79b3">
-            <HintPath>..\packages\NvAPIWrapper.Net.0.8.1.101\lib\net45\NvAPIWrapper.dll</HintPath>
-            <Private>True</Private>
-        </Reference>
-        <Reference Include="System"/>
-        <Reference Include="System.Data"/>
-        <Reference Include="System.Numerics"/>
-        <Reference Include="System.Runtime.Serialization"/>
-        <Reference Include="System.Windows.Forms"/>
-        <Reference Include="System.Xml"/>
-        <Reference Include="Microsoft.CSharp"/>
-        <Reference Include="System.Core"/>
-        <Reference Include="System.Xml.Linq"/>
-        <Reference Include="System.Data.DataSetExtensions"/>
-        <Reference Include="System.Net.Http"/>
-        <Reference Include="System.Xaml">
-            <RequiredTargetFramework>4.0</RequiredTargetFramework>
-        </Reference>
-        <Reference Include="WindowsBase"/>
-        <Reference Include="PresentationCore"/>
-        <Reference Include="PresentationFramework"/>
-        <Reference Include="WindowsDisplayAPI, Version=1.3.0.13, Culture=neutral, PublicKeyToken=null">
-            <HintPath>..\packages\WindowsDisplayAPI.1.3.0.13\lib\net45\WindowsDisplayAPI.dll</HintPath>
-            <Private>True</Private>
-        </Reference>
-    </ItemGroup>
-    <ItemGroup>
-        <ApplicationDefinition Include="App.xaml">
-            <Generator>MSBuild:Compile</Generator>
-            <SubType>Designer</SubType>
-        </ApplicationDefinition>
-        <Compile Include="AboutWindow.xaml.cs">
-            <DependentUpon>AboutWindow.xaml</DependentUpon>
-        </Compile>
-        <Compile Include="Lut16.cs"/>
-        <Compile Include="DoubleToneCurve.cs"/>
-        <Compile Include="RangeRule.cs"/>
-        <Compile Include="GammaToneCurve.cs"/>
-        <Compile Include="ICCBinaryReader.cs"/>
-        <Compile Include="ICCProfileException.cs"/>
-        <Compile Include="SrgbEOTF.cs"/>
-        <Compile Include="ToneCurve.cs"/>
-        <Page Include="AboutWindow.xaml"/>
-        <Page Include="MainWindow.xaml">
-            <Generator>MSBuild:Compile</Generator>
-            <SubType>Designer</SubType>
-        </Page>
-        <Compile Include="AdvancedViewModel.cs"/>
-        <Compile Include="App.xaml.cs">
-            <DependentUpon>App.xaml</DependentUpon>
-            <SubType>Code</SubType>
-        </Compile>
-        <Compile Include="Colorimetry.cs"/>
-        <Compile Include="LutToneCurve.cs"/>
-        <Compile Include="MainViewModel.cs"/>
-        <Compile Include="MainWindow.xaml.cs">
-            <DependentUpon>MainWindow.xaml</DependentUpon>
-            <SubType>Code</SubType>
-        </Compile>
-        <Page Include="AdvancedWindow.xaml"/>
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Include="Matrix.cs"/>
-        <Compile Include="ICCMatrixProfile.cs"/>
-        <Compile Include="MonitorData.cs"/>
-        <Compile Include="Novideo.cs"/>
-        <Compile Include="AdvancedWindow.xaml.cs">
-            <DependentUpon>AdvancedWindow.xaml</DependentUpon>
-        </Compile>
-        <Compile Include="Properties\AssemblyInfo.cs">
-            <SubType>Code</SubType>
-        </Compile>
-        <Compile Include="Properties\Resources.Designer.cs">
-            <AutoGen>True</AutoGen>
-            <DesignTime>True</DesignTime>
-            <DependentUpon>Resources.resx</DependentUpon>
-        </Compile>
-        <Compile Include="Properties\Settings.Designer.cs">
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Settings.settings</DependentUpon>
-            <DesignTimeSharedInput>True</DesignTimeSharedInput>
-        </Compile>
-        <EmbeddedResource Include="Properties\Resources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <None Include="packages.config"/>
-        <None Include="Properties\Settings.settings">
-            <Generator>SettingsSingleFileGenerator</Generator>
-            <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-        </None>
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="App.config"/>
-    </ItemGroup>
-    <ItemGroup>
-        <Resource Include="icon.ico"/>
-    </ItemGroup>
-    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets"/>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A6A97834-7BE1-474A-B92F-A512DB1D5186}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <RootNamespace>novideo_srgb</RootNamespace>
+    <AssemblyName>novideo_srgb</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <WarningLevel>4</WarningLevel>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>none</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationIcon>icon.ico</ApplicationIcon>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="EDIDParser, Version=1.2.5.3, Culture=neutral, PublicKeyToken=310fd07b25df79b3">
+      <HintPath>..\packages\EDIDParser.1.2.5.4\lib\net45\EDIDParser.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NvAPIWrapper, Version=0.8.1.100, Culture=neutral, PublicKeyToken=310fd07b25df79b3">
+      <HintPath>..\packages\NvAPIWrapper.Net.0.8.1.101\lib\net45\NvAPIWrapper.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xaml">
+      <RequiredTargetFramework>4.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="WindowsBase" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="WindowsDisplayAPI, Version=1.3.0.13, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\WindowsDisplayAPI.1.3.0.13\lib\net45\WindowsDisplayAPI.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <ApplicationDefinition Include="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </ApplicationDefinition>
+    <Compile Include="AboutWindow.xaml.cs">
+      <DependentUpon>AboutWindow.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="DisplayConfigManager.cs" />
+    <Compile Include="Lut16.cs" />
+    <Compile Include="DoubleToneCurve.cs" />
+    <Compile Include="PowerBroadcast\ConsoleDisplayState.cs" />
+    <Compile Include="PowerBroadcast\PowerBroadcastMessage.cs" />
+    <Compile Include="PowerBroadcast\PowerBroadcastNotificationHelpers.cs" />
+    <Compile Include="PowerBroadcast\PowerSettingGuids.cs" />
+    <Compile Include="RangeRule.cs" />
+    <Compile Include="GammaToneCurve.cs" />
+    <Compile Include="ICCBinaryReader.cs" />
+    <Compile Include="ICCProfileException.cs" />
+    <Compile Include="SrgbEOTF.cs" />
+    <Compile Include="ToneCurve.cs" />
+    <Page Include="AboutWindow.xaml" />
+    <Page Include="MainWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Compile Include="AdvancedViewModel.cs" />
+    <Compile Include="App.xaml.cs">
+      <DependentUpon>App.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Colorimetry.cs" />
+    <Compile Include="LutToneCurve.cs" />
+    <Compile Include="MainViewModel.cs" />
+    <Compile Include="MainWindow.xaml.cs">
+      <DependentUpon>MainWindow.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Page Include="AdvancedWindow.xaml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Matrix.cs" />
+    <Compile Include="ICCMatrixProfile.cs" />
+    <Compile Include="MonitorData.cs" />
+    <Compile Include="Novideo.cs" />
+    <Compile Include="AdvancedWindow.xaml.cs">
+      <DependentUpon>AdvancedWindow.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Properties\Resources.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+    <Compile Include="Properties\Settings.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+    </Compile>
+    <EmbeddedResource Include="Properties\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <None Include="packages.config" />
+    <None Include="Properties\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Resource Include="icon.ico" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
* Automatically reapply monitor clamp whenever the display is awakened from sleep. This is a workaround for an NVIDIA bug that causes the setting to be ignored after Windows puts the display to sleep on some hardware configurations.

* Automatically disable the clamp when HDR is turned on in Windows, and re-enable when HDR is turned off. (Win+Alt+B users rejoice). Resolves issue #4 .

* Minimize to tray feature, allowing the above features to operate quietly in the background. Resolves issue #16