### PR TITLE
Add ability to disable clamp automatically when specific program is running and some fixes

### DIFF
--- a/novideo_srgb/AdvancedViewModel.cs
+++ b/novideo_srgb/AdvancedViewModel.cs
@@ -21,6 +21,7 @@ namespace novideo_srgb
         private double _customGamma;
         private double _customPercentage;
         private bool _disableOptimization;
+        private string _ignore;
 
         private int _ditherState;
         private int _ditherMode;
@@ -43,6 +44,7 @@ namespace novideo_srgb
             _customGamma = monitor.CustomGamma;
             _customPercentage = monitor.CustomPercentage;
             _disableOptimization = monitor.DisableOptimization;
+            _ignore = monitor.Ignore;
 
             _ditherBits = dither.bits;
             _ditherMode = dither.mode;
@@ -67,6 +69,8 @@ namespace novideo_srgb
             _monitor.CustomPercentage = _customPercentage;
             ChangedCalibration |= _monitor.DisableOptimization != _disableOptimization;
             _monitor.DisableOptimization = _disableOptimization;
+            ChangedCalibration |= _monitor.Ignore != _ignore;
+            _monitor.Ignore = _ignore;
         }
 
         public ChromaticityCoordinates Coords => _monitor.Edid.DisplayParameters.ChromaticityCoordinates;
@@ -185,6 +189,17 @@ namespace novideo_srgb
                 OnPropertyChanged();
             }
             get => _disableOptimization;
+        }
+
+        public string Ignore
+        {
+            set
+            {
+                if (value == _ignore) return;
+                _ignore = value;
+                OnPropertyChanged();
+            }
+            get => _ignore;
         }
 
         public bool ChangedCalibration { get; set; }

--- a/novideo_srgb/AdvancedWindow.xaml
+++ b/novideo_srgb/AdvancedWindow.xaml
@@ -155,6 +155,15 @@
                         <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
                             <CheckBox IsChecked="{Binding DisableOptimization}" VerticalAlignment="Center">Disable 8-bit color optimization</CheckBox>
                         </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
+                            <TextBlock>Disable when</TextBlock>
+                            <TextBox VerticalContentAlignment="Center" 
+                                     Width="90" 
+                                     Margin="6,0,0,0"
+                                     Text="{Binding Ignore}">
+                            </TextBox>
+                            <TextBlock Margin="6,0,0,0"> is active</TextBlock>
+                        </StackPanel>
                     </StackPanel>
                 </RadioButton>
             </StackPanel>

--- a/novideo_srgb/MainViewModel.cs
+++ b/novideo_srgb/MainViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Windows.Forms;
 using System.Xml.Linq;
 using Microsoft.Win32;
@@ -12,6 +13,7 @@ namespace novideo_srgb
 {
     public class MainViewModel
     {
+        private static SemaphoreSlim _lockSemaphoreSlim = new SemaphoreSlim(1, 1);
         public ObservableCollection<MonitorData> Monitors { get; }
 
         private string _configPath;
@@ -132,10 +134,9 @@ namespace novideo_srgb
 
         public void SaveConfig()
         {
-            var _saveLock = new object();
             try
             {
-                lock(_saveLock)
+                if(_lockSemaphoreSlim.Wait(100))
                 {
                     if (File.Exists(_configPath))
                     {

--- a/novideo_srgb/MainViewModel.cs
+++ b/novideo_srgb/MainViewModel.cs
@@ -132,60 +132,64 @@ namespace novideo_srgb
 
         public void SaveConfig()
         {
+            var _saveLock = new object();
             try
             {
-                if (File.Exists(_configPath))
+                lock(_saveLock)
                 {
-                    var monitors = XElement.Load(_configPath);
-                    foreach (var monitor in Monitors)
+                    if (File.Exists(_configPath))
                     {
-                        var current = monitors.Elements().FirstOrDefault(x => x.Attribute("path").Value == monitor.Path);
-                        if (current != default) // If current exist in config, update
+                        var monitors = XElement.Load(_configPath);
+                        foreach (var monitor in Monitors)
                         {
-                            current.SetAttributeValue("clamp_sdr", monitor.ClampSdr);
-                            current.SetAttributeValue("use_icc", monitor.UseIcc);
-                            current.SetAttributeValue("icc_path", monitor.ProfilePath);
-                            current.SetAttributeValue("calibrate_gamma", monitor.CalibrateGamma);
-                            current.SetAttributeValue("selected_gamma", monitor.SelectedGamma);
-                            current.SetAttributeValue("custom_gamma", monitor.CustomGamma);
-                            current.SetAttributeValue("custom_percentage", monitor.CustomPercentage);
-                            current.SetAttributeValue("target", monitor.Target);
-                            current.SetAttributeValue("disable_optimization", monitor.DisableOptimization);
-                            current.SetAttributeValue("ignore", monitor.Ignore);
+                            var current = monitors.Elements().FirstOrDefault(x => x.Attribute("path").Value == monitor.Path);
+                            if (current != default) // If current exist in config, update
+                            {
+                                current.SetAttributeValue("clamp_sdr", monitor.ClampSdr);
+                                current.SetAttributeValue("use_icc", monitor.UseIcc);
+                                current.SetAttributeValue("icc_path", monitor.ProfilePath);
+                                current.SetAttributeValue("calibrate_gamma", monitor.CalibrateGamma);
+                                current.SetAttributeValue("selected_gamma", monitor.SelectedGamma);
+                                current.SetAttributeValue("custom_gamma", monitor.CustomGamma);
+                                current.SetAttributeValue("custom_percentage", monitor.CustomPercentage);
+                                current.SetAttributeValue("target", monitor.Target);
+                                current.SetAttributeValue("disable_optimization", monitor.DisableOptimization);
+                                current.SetAttributeValue("ignore", monitor.Ignore);
+                            }
+                            else // otherwise, add
+                            {
+                                monitors.Add(new XElement("monitor", new XAttribute("path", monitor.Path),
+                                    new XAttribute("clamp_sdr", monitor.ClampSdr),
+                                    new XAttribute("use_icc", monitor.UseIcc),
+                                    new XAttribute("icc_path", monitor.ProfilePath),
+                                    new XAttribute("calibrate_gamma", monitor.CalibrateGamma),
+                                    new XAttribute("selected_gamma", monitor.SelectedGamma),
+                                    new XAttribute("custom_gamma", monitor.CustomGamma),
+                                    new XAttribute("custom_percentage", monitor.CustomPercentage),
+                                    new XAttribute("target", monitor.Target),
+                                    new XAttribute("disable_optimization", monitor.DisableOptimization),
+                                    new XAttribute("ignore", monitor.Ignore)));
+                            }
                         }
-                        else // otherwise, add
-                        {
-                            monitors.Add(new XElement("monitor", new XAttribute("path", monitor.Path),
-                                new XAttribute("clamp_sdr", monitor.ClampSdr),
-                                new XAttribute("use_icc", monitor.UseIcc),
-                                new XAttribute("icc_path", monitor.ProfilePath),
-                                new XAttribute("calibrate_gamma", monitor.CalibrateGamma),
-                                new XAttribute("selected_gamma", monitor.SelectedGamma),
-                                new XAttribute("custom_gamma", monitor.CustomGamma),
-                                new XAttribute("custom_percentage", monitor.CustomPercentage),
-                                new XAttribute("target", monitor.Target),
-                                new XAttribute("disable_optimization", monitor.DisableOptimization),
-                                new XAttribute("ignore", monitor.Ignore)));
-                        }
+                        monitors.Save(_configPath);
                     }
-                    monitors.Save(_configPath);
-                }
-                else
-                {
-                    var xElem = new XElement("monitors",
-                        Monitors.Select(x =>
-                            new XElement("monitor", new XAttribute("path", x.Path),
-                                new XAttribute("clamp_sdr", x.ClampSdr),
-                                new XAttribute("use_icc", x.UseIcc),
-                                new XAttribute("icc_path", x.ProfilePath),
-                                new XAttribute("calibrate_gamma", x.CalibrateGamma),
-                                new XAttribute("selected_gamma", x.SelectedGamma),
-                                new XAttribute("custom_gamma", x.CustomGamma),
-                                new XAttribute("custom_percentage", x.CustomPercentage),
-                                new XAttribute("target", x.Target),
-                                new XAttribute("disable_optimization", x.DisableOptimization),
-                                new XAttribute("ignore", x.Ignore))));
-                    xElem.Save(_configPath);
+                    else
+                    {
+                        var xElem = new XElement("monitors",
+                            Monitors.Select(x =>
+                                new XElement("monitor", new XAttribute("path", x.Path),
+                                    new XAttribute("clamp_sdr", x.ClampSdr),
+                                    new XAttribute("use_icc", x.UseIcc),
+                                    new XAttribute("icc_path", x.ProfilePath),
+                                    new XAttribute("calibrate_gamma", x.CalibrateGamma),
+                                    new XAttribute("selected_gamma", x.SelectedGamma),
+                                    new XAttribute("custom_gamma", x.CustomGamma),
+                                    new XAttribute("custom_percentage", x.CustomPercentage),
+                                    new XAttribute("target", x.Target),
+                                    new XAttribute("disable_optimization", x.DisableOptimization),
+                                    new XAttribute("ignore", x.Ignore))));
+                        xElem.Save(_configPath);
+                    }
                 }
             }
             catch (Exception ex)

--- a/novideo_srgb/MainViewModel.cs
+++ b/novideo_srgb/MainViewModel.cs
@@ -13,7 +13,7 @@ namespace novideo_srgb
 {
     public class MainViewModel
     {
-        private static SemaphoreSlim _lockSemaphoreSlim = new SemaphoreSlim(1, 1);
+        private readonly static SemaphoreSlim _saveSemaphoreSlim = new SemaphoreSlim(1, 1);
         public ObservableCollection<MonitorData> Monitors { get; }
 
         private string _configPath;
@@ -136,7 +136,7 @@ namespace novideo_srgb
         {
             try
             {
-                if(_lockSemaphoreSlim.Wait(100))
+                if(_saveSemaphoreSlim.Wait(100))
                 {
                     if (File.Exists(_configPath))
                     {
@@ -191,6 +191,7 @@ namespace novideo_srgb
                                     new XAttribute("ignore", x.Ignore))));
                         xElem.Save(_configPath);
                     }
+                    _saveSemaphoreSlim.Release();
                 }
             }
             catch (Exception ex)

--- a/novideo_srgb/MainViewModel.cs
+++ b/novideo_srgb/MainViewModel.cs
@@ -96,7 +96,8 @@ namespace novideo_srgb
                         (double)settings.Attribute("custom_gamma"),
                         (double)settings.Attribute("custom_percentage"),
                         (int)settings.Attribute("target"),
-                        (bool)settings.Attribute("disable_optimization"));
+                        (bool)settings.Attribute("disable_optimization"),
+                        (string)settings.Attribute("ignore"));
                 }
                 else
                 {
@@ -114,7 +115,13 @@ namespace novideo_srgb
 
         public void OnDisplaySettingsChanged(object sender, EventArgs e)
         {
-            UpdateMonitors();
+            try
+            {
+                UpdateMonitors();
+            }
+            catch
+            {
+            }
         }
 
         public void OnPowerModeChanged(object sender, PowerModeChangedEventArgs e)
@@ -127,19 +134,59 @@ namespace novideo_srgb
         {
             try
             {
-                var xElem = new XElement("monitors",
-                    Monitors.Select(x =>
-                        new XElement("monitor", new XAttribute("path", x.Path),
-                            new XAttribute("clamp_sdr", x.ClampSdr),
-                            new XAttribute("use_icc", x.UseIcc),
-                            new XAttribute("icc_path", x.ProfilePath),
-                            new XAttribute("calibrate_gamma", x.CalibrateGamma),
-                            new XAttribute("selected_gamma", x.SelectedGamma),
-                            new XAttribute("custom_gamma", x.CustomGamma),
-                            new XAttribute("custom_percentage", x.CustomPercentage),
-                            new XAttribute("target", x.Target),
-                            new XAttribute("disable_optimization", x.DisableOptimization))));
-                xElem.Save(_configPath);
+                if (File.Exists(_configPath))
+                {
+                    var monitors = XElement.Load(_configPath);
+                    foreach (var monitor in Monitors)
+                    {
+                        var current = monitors.Elements().FirstOrDefault(x => x.Attribute("path").Value == monitor.Path);
+                        if (current != default) // If current exist in config, update
+                        {
+                            current.SetAttributeValue("clamp_sdr", monitor.ClampSdr);
+                            current.SetAttributeValue("use_icc", monitor.UseIcc);
+                            current.SetAttributeValue("icc_path", monitor.ProfilePath);
+                            current.SetAttributeValue("calibrate_gamma", monitor.CalibrateGamma);
+                            current.SetAttributeValue("selected_gamma", monitor.SelectedGamma);
+                            current.SetAttributeValue("custom_gamma", monitor.CustomGamma);
+                            current.SetAttributeValue("custom_percentage", monitor.CustomPercentage);
+                            current.SetAttributeValue("target", monitor.Target);
+                            current.SetAttributeValue("disable_optimization", monitor.DisableOptimization);
+                            current.SetAttributeValue("ignore", monitor.Ignore);
+                        }
+                        else // otherwise, add
+                        {
+                            monitors.Add(new XElement("monitor", new XAttribute("path", monitor.Path),
+                                new XAttribute("clamp_sdr", monitor.ClampSdr),
+                                new XAttribute("use_icc", monitor.UseIcc),
+                                new XAttribute("icc_path", monitor.ProfilePath),
+                                new XAttribute("calibrate_gamma", monitor.CalibrateGamma),
+                                new XAttribute("selected_gamma", monitor.SelectedGamma),
+                                new XAttribute("custom_gamma", monitor.CustomGamma),
+                                new XAttribute("custom_percentage", monitor.CustomPercentage),
+                                new XAttribute("target", monitor.Target),
+                                new XAttribute("disable_optimization", monitor.DisableOptimization)),
+                                new XAttribute("ignore", monitor.Ignore));
+                        }
+                    }
+                    monitors.Save(_configPath);
+                }
+                else
+                {
+                    var xElem = new XElement("monitors",
+                        Monitors.Select(x =>
+                            new XElement("monitor", new XAttribute("path", x.Path),
+                                new XAttribute("clamp_sdr", x.ClampSdr),
+                                new XAttribute("use_icc", x.UseIcc),
+                                new XAttribute("icc_path", x.ProfilePath),
+                                new XAttribute("calibrate_gamma", x.CalibrateGamma),
+                                new XAttribute("selected_gamma", x.SelectedGamma),
+                                new XAttribute("custom_gamma", x.CustomGamma),
+                                new XAttribute("custom_percentage", x.CustomPercentage),
+                                new XAttribute("target", x.Target),
+                                new XAttribute("disable_optimization", x.DisableOptimization),
+                                new XAttribute("ignore", x.Ignore))));
+                    xElem.Save(_configPath);
+                }
             }
             catch (Exception ex)
             {

--- a/novideo_srgb/MainViewModel.cs
+++ b/novideo_srgb/MainViewModel.cs
@@ -164,8 +164,8 @@ namespace novideo_srgb
                                 new XAttribute("custom_gamma", monitor.CustomGamma),
                                 new XAttribute("custom_percentage", monitor.CustomPercentage),
                                 new XAttribute("target", monitor.Target),
-                                new XAttribute("disable_optimization", monitor.DisableOptimization)),
-                                new XAttribute("ignore", monitor.Ignore));
+                                new XAttribute("disable_optimization", monitor.DisableOptimization),
+                                new XAttribute("ignore", monitor.Ignore)));
                         }
                     }
                     monitors.Save(_configPath);

--- a/novideo_srgb/MainWindow.xaml.cs
+++ b/novideo_srgb/MainWindow.xaml.cs
@@ -28,6 +28,13 @@ namespace novideo_srgb
             _viewModel = (MainViewModel)DataContext;
             SystemEvents.DisplaySettingsChanged += _viewModel.OnDisplaySettingsChanged;
             SystemEvents.PowerModeChanged += _viewModel.OnPowerModeChanged;
+            Closed += delegate
+            {
+                // https://learn.microsoft.com/en-us/dotnet/api/microsoft.win32.systemevents.displaysettingschanged
+                // Because this is a static event, you must detach your event handlers when your application is disposed, or memory leaks will result.
+                SystemEvents.DisplaySettingsChanged -= _viewModel.OnDisplaySettingsChanged;
+                SystemEvents.PowerModeChanged -= _viewModel.OnPowerModeChanged;
+            };
 
             var args = Environment.GetCommandLineArgs().ToList();
             args.RemoveAt(0);

--- a/novideo_srgb/MonitorData.cs
+++ b/novideo_srgb/MonitorData.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using EDIDParser;
 using EDIDParser.Descriptors;
@@ -20,6 +23,14 @@ namespace novideo_srgb
         private bool _clamped;
 
         private MainViewModel _viewModel;
+
+        // https://stackoverflow.com/questions/647270/how-to-refresh-the-windows-desktop-programmatically-i-e-f5-from-c
+        [System.Runtime.InteropServices.DllImport("Shell32.dll")]
+        private static extern int SHChangeNotify(int eventId, int flags, IntPtr item1, IntPtr item2);
+        // https://stackoverflow.com/questions/2655944/determine-if-a-window-is-visible-or-not-using-c-sharp
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool IsWindowVisible(IntPtr hWnd);
 
         public MonitorData(MainViewModel viewModel, int number, Display display, string path, bool hdrActive, bool clampSdr)
         {
@@ -50,11 +61,65 @@ namespace novideo_srgb
             ProfilePath = "";
             CustomGamma = 2.2;
             CustomPercentage = 100;
+            Ignore = "";
+
+            _ = Task.Run(async () =>
+            {
+                while (true)
+                {
+                    try
+                    {
+                        if (!string.IsNullOrEmpty(Ignore) && Clamped)
+                        {
+                            var split = Ignore.Split('\\');
+                            if (split.Length > 0)
+                            {
+                                var process = split.SelectMany(x => Process.GetProcessesByName(x));
+                                if (process.Any())
+                                {
+                                    foreach (var p in process.Where(x => IsWindowVisible(x.MainWindowHandle)))
+                                    {
+                                        var deviceName = System.Windows.Forms.Screen.FromHandle(p.MainWindowHandle).DeviceName;
+                                        var devicePath = WindowsDisplayAPI.Display.GetDisplays().First(x => x.DisplayName == deviceName).DevicePath;
+                                        if (Path == devicePath)
+                                        {
+                                            Clamped = false;
+                                            p.Exited += ReclampOnExit;
+                                            while (!p.HasExited)
+                                            {
+                                                var dn = System.Windows.Forms.Screen.FromHandle(p.MainWindowHandle).DeviceName;
+                                                // Moved to another monitor without closing
+                                                if (deviceName != dn)
+                                                {
+                                                    // Restore(reappply)
+                                                    Clamped = true;
+                                                    p.Exited -= ReclampOnExit;
+                                                    break;
+                                                }
+                                                await Task.Delay(1000);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        await Task.Delay(1000);
+                    }
+                    catch (Exception e)
+                    {
+                        MessageBox.Show(e.ToString());
+                    }
+                }
+                void ReclampOnExit(object sender, EventArgs e)
+                {
+                    Clamped = true;
+                }
+            });
         }
 
         public MonitorData(MainViewModel viewModel, int number, Display display, string path, bool hdrActive, bool clampSdr, bool useIcc, string profilePath,
             bool calibrateGamma,
-            int selectedGamma, double customGamma, double customPercentage, int target, bool disableOptimization) :
+            int selectedGamma, double customGamma, double customPercentage, int target, bool disableOptimization, string ignore) :
             this(viewModel, number, display, path, hdrActive, clampSdr)
         {
             UseIcc = useIcc;
@@ -65,6 +130,7 @@ namespace novideo_srgb
             CustomPercentage = customPercentage;
             Target = target;
             DisableOptimization = disableOptimization;
+            Ignore = ignore;
         }
 
         public int Number { get; }
@@ -128,6 +194,7 @@ namespace novideo_srgb
                     Novideo.SetColorSpaceConversion(_output, profile, TargetColorSpace);
                 }
             }
+            SHChangeNotify(0x8000000, 0x1000, IntPtr.Zero, IntPtr.Zero);
         }
 
         private void HandleClampException(Exception e)
@@ -138,7 +205,7 @@ namespace novideo_srgb
             _viewModel.SaveConfig();
             OnPropertyChanged(nameof(Clamped));
         }
-        
+
         public bool Clamped
         {
             set
@@ -199,6 +266,7 @@ namespace novideo_srgb
         public double CustomPercentage { set; get; }
 
         public bool DisableOptimization { set; get; }
+        public string Ignore { set; get; }
 
         public int Target { set; get; }
 

--- a/novideo_srgb/Novideo.cs
+++ b/novideo_srgb/Novideo.cs
@@ -178,7 +178,18 @@ namespace novideo_srgb
             var status = NvAPI_GPU_SetColorSpaceConversion(displayId, ref csc);
             if (status != 0)
             {
-                throw new Exception("NvAPI_GPU_SetColorSpaceConversion failed with error code " + status);
+                if (status == -104)
+                {
+                    if (!_alerted)
+                    {
+                        System.Windows.Forms.MessageBox.Show("Please disable clamp before enable HDR, for more information, see #71 issue.\r\nThis warning won't show again until next launch", "novideo_srgb");
+                        _alerted = true;
+                    }
+                }
+                else
+                {
+                    throw new Exception("NvAPI_GPU_SetColorSpaceConversion failed with error code " + status);
+                }
             }
         }
 
@@ -276,7 +287,18 @@ namespace novideo_srgb
                 var status = NvAPI_GPU_SetColorSpaceConversion(displayId, ref csc);
                 if (status != 0)
                 {
-                    throw new Exception("NvAPI_GPU_SetColorSpaceConversion failed with error code " + status);
+                    if (status == -104)
+                    {
+                        if (!_alerted)
+                        {
+                            System.Windows.Forms.MessageBox.Show("Please disable clamp before enable HDR, for more information, see #71 issue.\r\nThis warning won't show again until next launch", "novideo_srgb");
+                            _alerted = true;
+                        }
+                    }
+                    else
+                    {
+                        throw new Exception("NvAPI_GPU_SetColorSpaceConversion failed with error code " + status);
+                    }
                 }
             }
         }
@@ -336,7 +358,7 @@ namespace novideo_srgb
         public static DitherControl GetDitherControl(GPUOutput output)
         {
             var dither = new Dither
-                { version = 0x10018 };
+            { version = 0x10018 };
             var status = NvAPI_GPU_GetDitherControl(output.PhysicalGPU.GetDisplayDeviceByOutput(output).DisplayId,
                 ref dither);
             if (status != 0)
@@ -371,5 +393,7 @@ namespace novideo_srgb
                 Marshal.GetDelegateForFunctionPointer<NvAPI_GPU_SetDitherControl_t>(
                     NvAPI_QueryInterface(_NvAPI_GPU_SetDitherControl));
         }
+#warning Remove this after #71 was fixed
+        private static bool _alerted = false;
     }
 }


### PR DESCRIPTION
`Add ability to disable clamp automatically when specific program is running`
Input executable file name(without extension) and split by \ (as it's not a valid character in file name), it will disable&re-enable automatically when program open/close/move to another monitor. Useful when using some well-color-managemented program like madvr

`Update config instead of always overwrite to prevent losing configs `
Useful when temporary disconnect monitor and connect later, and useful for some odd monitors like Samsung Neo G8 (has different model between 120Hz mode and 240Hz mode)

`Catch exceptions in OnDisplaySettingsChanged to prevent event doesn't work`
Occures when switching from sdr to hdr, it will throw exceptions like -104 or "elements in a collection was modified" and this event won't raise anymore, 

`Send refresh event to desktop to prevent greyed out`
It may be a bug that only occurs in multiple monitors configuration. The color is like a gamma with only 1, and require a click/refresh to recovery

`Change error -104 to alert and only show once per launch`
It's a bit annoying

Not much debugging, but it looks okay